### PR TITLE
Location of inc-folder should be defined only once

### DIFF
--- a/nopriv.py
+++ b/nopriv.py
@@ -88,6 +88,7 @@ enable_html = True
 CreateMailDir = True
 messages_per_overview_page = 50
 
+inc_location = "inc"
 
 def connectToImapMailbox(IMAPSERVER, IMAPLOGIN, IMAPPASSWORD):
     if ssl is True:
@@ -99,7 +100,7 @@ def connectToImapMailbox(IMAPSERVER, IMAPLOGIN, IMAPPASSWORD):
 
 maildir = 'NoPrivMaildir'
 
-def returnHeader(title, inclocation="inc", layout=1):
+def returnHeader(title, inclocation=inc_location, layout=1):
     if layout is 1:
         response = """
 <html>
@@ -822,7 +823,7 @@ for folder in IMAPFOLDER:
 
 for folder in IMAPFOLDER:
     print(("Processing folder: %s.") % folder)
-    copy("inc", folder + "/inc/")
+    copy(inc_location, folder + "/inc/")
     backup_mails_to_html_from_local_maildir(folder)
     print(("Done with folder: %s.") % folder)
     print("\n")    


### PR DESCRIPTION
Would be nice to only change one variable if the inc-folder is placed somewhere else. That would also make the life of maintainers easier, that will have to place inc somewhere else - e.g. /usr/local/share/nopriv/inc.

Btw, you can take a look at my fpm makefile[1}.
With fpm[2] and the makefile from my bitbucket repo you can generate a packages for deb and rpm.

[1] https://bitbucket.org/brejoc/fpm-makefiles/src/tip/nopriv?at=default
[2]https://github.com/jordansissel/fpm/wiki
